### PR TITLE
ACME / Let's Encrypt Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
 **
 !/Makefile
 !/aux
+!/base16.c
+!/base16.h
+!/base32.c
+!/base32.h
 !/netip.c
 !/nginx.conf
+!/seal.c
+!/seal.h
 !/web

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3 AS build
 RUN apk update \
- && apk add git make gcc libc-dev
+ && apk add git make gcc libc-dev libsodium-dev
 WORKDIR /build
 COPY . .
 RUN make clean netip \
@@ -17,6 +17,9 @@ LABEL maintainer="James Hunt <images@huntprod.com>" \
       org.label-schema.vcs-url="https://github.com/jhunt/netip.cc.git" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.schema-version="1.0.0"
+
+RUN apk update \
+ && apk add libsodium
 
 COPY --from=build /build/netip /usr/bin/netip
 COPY aux/netip /netip

--- a/base16.c
+++ b/base16.c
@@ -1,0 +1,127 @@
+#include <stddef.h>
+#include <string.h>
+
+#include "base16.h"
+
+static char ALPHA[16] = "0123456789abcdef";
+static char LOOKUP[256] = {
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+};
+
+void b16a(const char *alpha) {
+	const char *c;
+	memset(LOOKUP, 0, sizeof(LOOKUP));
+	for (c = alpha; *c; c++) {
+		ALPHA[c-alpha] = *c;
+		LOOKUP[*c] = c-alpha;
+	}
+}
+
+/*
+
+          [0]
+   1b: 01234567
+
+   2b: 0123 4567
+         ^    ^
+         |    `--- ([0]     ) & 0x0f
+         `-------- ([0] >> 4) & 0x0f
+
+    01234567
+    0123----  [0] >> 4
+
+    01234567
+    ----4567  [0]
+
+
+    0123 4567
+    0123 4567   [0] << 4 | [1]
+
+ */
+
+
+int
+b16e(char *dst, const char *src, size_t inlen)
+{
+	for (; inlen > 0; src += 1, inlen -= 1) {
+		*dst++ = ALPHA[(0xf0 & src[0]) >> 4];
+		*dst++ = ALPHA[(0x0f & src[0])     ];
+	}
+	return 0;
+}
+
+int
+b16d(char *dst, const char *src, size_t inlen)
+{
+	if (inlen % 2 != 0)
+		return 1;
+
+	for (; inlen >= 2; src += 2, inlen -= 2) {
+		*dst++ = (LOOKUP[src[0]] << 4) | (LOOKUP[src[1]]);
+	}
+	return 0;
+}
+
+#ifdef O_TESTS
+#include "ctap.h"
+
+#define b16_is(buf, in, out) do {\
+	memset(buf, 0, sizeof(buf)); \
+	ok(b16e(buf, in, strlen(in)) == 0, "b16e(" in ") should succeed"); \
+	buf[b16elen(strlen(in))] = '\0'; \
+	is(buf, out, "[" in "] is [" out "] in base16"); \
+	\
+	memset(buf, 0, sizeof(buf)); \
+	ok(b16d(buf, out, strlen(out)) == 0, "b16d(" out ") should succeed"); \
+	buf[b16dlen(strlen(out))] = '\0'; \
+	is(buf, in, "[" out "] in base16 is [" in "]"); \
+} while (0)
+
+#define b16_uses(e,d) do {\
+	cmp_ok(b16elen(e), "==", d, "base-16 needs %d bytes to encode %d bytes", e, d); \
+	cmp_ok(b16dlen(d), "==", e, "base-16 needs %d bytes to decode %d bytes", d, e); \
+} while (0)
+
+#define b16_noop(buf, s) do {\
+	memset(buf, 0, sizeof(buf)); \
+	ok(b16e(buf, s, strlen(s)) == 0, "b16e(" s ") should succeed"); \
+	ok(b16d(buf, buf, b16elen(strlen(s))) == 0, "b16d(b16e(" s ")) should also succeed"); \
+	buf[b16dlen(b16elen(strlen(s)))] = '\0'; \
+	is(buf, s, "D(E(s)) should equal (s)"); \
+} while (0)
+
+TESTS {
+	char buf[256];
+
+	b16_uses(1,2); b16_uses(2,4); b16_uses(3,6);
+	b16_uses(4,8); /* you get the idea */
+
+	cmp_ok(b16elen(7), "==", 14, "base-16 uses double the space for encoding");
+	cmp_ok(b16dlen(14), "==", 7, "base-16 uses half the space for decoding");
+
+	b16_is(buf, "f",      "66");
+	b16_is(buf, "fo",     "666f");
+	b16_is(buf, "foo",    "666f6f");
+	b16_is(buf, "foob",   "666f6f62");
+	b16_is(buf, "fooba",  "666f6f6261");
+	b16_is(buf, "foobar", "666f6f626172");
+
+	b16_noop(buf, "people say nothing is impossible, but i do nothing every day.");
+	b16_noop(buf, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+}
+#endif

--- a/base16.h
+++ b/base16.h
@@ -1,0 +1,18 @@
+#ifndef BASE16_H
+#define BASE16_H
+
+static inline size_t
+b16elen(size_t dlen) {
+	return dlen * 2;
+}
+
+static inline size_t
+b16dlen(size_t elen) {
+	return elen / 2;
+}
+
+void b16a(const char *alpha);
+int b16d(char *dst, const char *src, size_t len);
+int b16e(char *dst, const char *src, size_t len);
+
+#endif

--- a/base32.c
+++ b/base32.c
@@ -1,0 +1,201 @@
+#include <stddef.h>
+#include <string.h>
+
+#include "base32.h"
+
+#define MASK 0x1f
+
+static char ALPHA[32] = "0123456789abcdefghijklmnopqrstuv";
+static char LOOKUP[256] = {
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+	   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+};
+
+void b32a(const char *alpha) {
+	const char *c;
+	memset(LOOKUP, 0, sizeof(LOOKUP));
+	for (c = alpha; *c; c++) {
+		ALPHA[c-alpha] = *c;
+		LOOKUP[*c] = c-alpha;
+	}
+}
+
+/*
+
+          [0]      [1]      [2]      [3]      [4]
+   8b: 01234567 01234567 01234567 01234567 01234567
+
+   5b: 01234 56701 23456 70123 45670 12345 67012 34567
+         ^     ^     ^     ^     ^     ^     ^     ^
+         |     |     |     |     |     |     |     `------ (           [4]     ) & 01xf
+         |     |     |     |     |     |     ` ----------- ([3] << 3 | [4] >> 5) & 0x1f
+         |     |     |     |     |     `------------------ (           [3] >> 2) & 0x1f
+         |     |     |     |     `------------------------ ([2] << 1 | [3] >> 7) & 0x1f
+         |     |     |     `------------------------------ ([1] << 4 | [2] >> 4) & 0x1f
+         |     |     `------------------------------------ (           [1] >> 1) & 0x1f
+         |     `------------------------------------------ ([0] << 2 | [1] >> 6) & 0x1f
+         `------------------------------------------------ (           [0] >> 3) & 0x1f
+
+    01234567
+    01234---   [0] >> 3
+
+    01234567 01234567
+    -----567 01------  [0] << 2 | [1] >> 6
+
+             01234567
+             --23456-  [1] >> 1
+
+             01234567 01234567
+             -------7 0123----  [1] << 4 | [2] >> 4
+
+                      01234567 01234567
+                      ----4567 0-------  [2] << 1 | [3] >> 7
+
+                               01234567
+                               -12345--  [3] >> 2
+
+                               01234567 01234567
+                               ------67 012----- [3] << 3 | [4] >> 5
+
+                                        01234567
+                                        ---34567 [4]
+
+    01234 56701
+    01234 567-- [0] << 3 | [1] >> 2
+
+          56701 23456 70123
+          ---01 23456 7----  [1] << 6 | [2] << 1 || [3] >> 4
+
+                      70123 45670
+                      -0123 4567-  [3] << 4 | [4] >> 1
+
+                            45670 12345 67012
+                            ----0 12345 67---  [4] << 7 | [5] << 2 | [6] >> 3
+
+                                        67012 34567
+                                        --012 34567  [6] << 5 | [7]
+
+ */
+
+
+int
+b32e(char *dst, const char *src, size_t inlen)
+{
+	char buf[5];
+	for (; inlen >= 5; src += 5, inlen -= 5) {
+		*dst++ = ALPHA[ (                         (0xf8 & src[0]) >> 3) & MASK];
+		*dst++ = ALPHA[ ((0x07 & src[0]) << 2) | ((0xc0 & src[1]) >> 6) & MASK];
+		*dst++ = ALPHA[ (                         (0x7f & src[1]) >> 1) & MASK];
+		*dst++ = ALPHA[ ((0x01 & src[1]) << 4) | ((0xf0 & src[2]) >> 4) & MASK];
+		*dst++ = ALPHA[ ((0x0f & src[2]) << 1) | ((0x80 & src[3]) >> 7) & MASK];
+		*dst++ = ALPHA[ (                         (0x7c & src[3]) >> 2) & MASK];
+		*dst++ = ALPHA[ ((0x03 & src[3]) << 3) | ((0xe0 & src[4]) >> 5) & MASK];
+		*dst++ = ALPHA[ (                         (0x1f & src[4])     ) & MASK];
+	}
+
+	if (inlen >= 1) {
+		/* bounce through a temporary (stack-local)
+		   buffer for our required 0-padding. */
+		memset(buf, 0, 5);
+		memcpy(buf, src, inlen);
+		src = buf;
+
+		*dst++ = ALPHA[ (                         (0xf8 & src[0]) >> 3) & MASK];
+		*dst++ = ALPHA[ ((0x07 & src[0]) << 2) | ((0xc0 & src[1]) >> 6) & MASK];
+	}
+	if (inlen >= 2) {
+		*dst++ = ALPHA[ (                         (0x7f & src[1]) >> 1) & MASK];
+		*dst++ = ALPHA[ ((0x01 & src[1]) << 4) | ((0xf0 & src[2]) >> 4) & MASK];
+	}
+	if (inlen >= 3) {
+		*dst++ = ALPHA[ ((0x0f & src[2]) << 1) | ((0x80 & src[3]) >> 7) & MASK];
+	}
+	if (inlen >= 4) {
+		*dst++ = ALPHA[ (                         (0x7c & src[3]) >> 2) & MASK];
+		*dst++ = ALPHA[ ((0x03 & src[3]) << 3) | ((0xe0 & src[4]) >> 5) & MASK];
+	}
+	return 0;
+}
+
+int
+b32d(char *dst, const char *src, size_t inlen)
+{
+	switch (inlen % 8) {
+	case 1: case 3: case 6:
+		return 1;
+	}
+
+	for (; inlen >= 8; src += 8, inlen -= 8) {
+		*dst++ = (LOOKUP[src[0]] << 3) | (LOOKUP[src[1]] >> 2);
+		*dst++ = (LOOKUP[src[1]] << 6) | (LOOKUP[src[2]] << 1) | (LOOKUP[src[3]] >> 4);
+		*dst++ = (LOOKUP[src[3]] << 4) | (LOOKUP[src[4]] >> 1);
+		*dst++ = (LOOKUP[src[4]] << 7) | (LOOKUP[src[5]] << 2) | (LOOKUP[src[6]] >> 3);
+		*dst++ = (LOOKUP[src[6]] << 5) | (LOOKUP[src[7]]);
+	}
+	if (inlen >= 2) *dst++ = (LOOKUP[src[0]] << 3) | (LOOKUP[src[1]] >> 2);
+	if (inlen >= 4) *dst++ = (LOOKUP[src[1]] << 6) | (LOOKUP[src[2]] << 1) | (LOOKUP[src[3]] >> 4);
+	if (inlen >= 5) *dst++ = (LOOKUP[src[3]] << 4) | (LOOKUP[src[4]] >> 1);
+	if (inlen >= 7) *dst++ = (LOOKUP[src[4]] << 7) | (LOOKUP[src[5]] << 2) | (LOOKUP[src[6]] >> 3);
+	return 0;
+}
+
+#ifdef O_TESTS
+#include "ctap.h"
+
+#define b32_is(buf, in, out) do {\
+	memset(buf, 0, sizeof(buf)); \
+	ok(b32e(buf, in, strlen(in)) == 0, "b32e(" in ") should succeed"); \
+	buf[b32elen(strlen(in))] = '\0'; \
+	is(buf, out, "[" in "] is [" out "] in base32"); \
+	\
+	memset(buf, 0, sizeof(buf)); \
+	ok(b32d(buf, out, strlen(out)) == 0, "b32d(" out ") should succeed"); \
+	buf[b32dlen(strlen(out))] = '\0'; \
+	is(buf, in, "[" out "] in base32 is [" in "]"); \
+} while (0)
+
+#define b32_uses(e,d) do {\
+	cmp_ok(b32elen(e), "==", d, "base-32 needs %d bytes to encode %d bytes", e, d); \
+	cmp_ok(b32dlen(d), "==", e, "base-32 needs %d bytes to decode %d bytes", d, e); \
+} while (0)
+
+#define b32_noop(buf, s) do {\
+	memset(buf, 0, sizeof(buf)); \
+	ok(b32e(buf, s, strlen(s)) == 0, "b32e(" s ") should succeed"); \
+	ok(b32d(buf, buf, strlen(buf)) == 0, "b32d(b32e(" s ")) should also succeed"); \
+	buf[b32dlen(b32elen(strlen(s)))] = '\0'; \
+	is(buf, s, "D(E(s)) should equal (s)"); \
+} while (0)
+
+TESTS {
+	char buf[256];
+
+	b32_uses(1,2); b32_uses(2,4); b32_uses(3,5);
+	b32_uses(4,7); /* and repeat! */
+
+	b32_is(buf, "f",      "co");
+	b32_is(buf, "fo",     "cpng");
+	b32_is(buf, "foo",    "cpnmu");
+	b32_is(buf, "foob",   "cpnmuog");
+	b32_is(buf, "fooba",  "cpnmuoj1");
+	b32_is(buf, "foobar", "cpnmuoj1e8");
+	b32_is(buf, "\xbb\x68\x4a\x7c\x13\xa4\x77\xf4\x05\x18\xa4\x80", "ndk4kv0jkhrv818oki00");
+
+	b32_noop(buf, "people say nothing is impossible, but i do nothing every day.");
+	b32_noop(buf, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+}
+#endif

--- a/base32.h
+++ b/base32.h
@@ -1,0 +1,21 @@
+#ifndef BASE32_H
+#define BASE32_H
+
+#define BASE32_ALPHA     "abcdefghijklmnopqrstuvwxyz234567"
+#define BASE32_HEX_ALPHA "0123456789abcdefghijklmnopqrstuv"
+
+static inline size_t
+b32elen(size_t dlen) {
+	return (8*dlen) / 5 + (8*dlen % 5 == 0 ? 0 : 1);
+}
+
+static inline size_t
+b32dlen(size_t elen) {
+	return (5*elen) / 8;
+}
+
+void b32a(const char *alpha);
+int b32d(char *dst, const char *src, size_t len);
+int b32e(char *dst, const char *src, size_t len);
+
+#endif

--- a/netip.c
+++ b/netip.c
@@ -130,11 +130,11 @@ typedef struct {
 	size_t        used; /* how many cache entries are valid?  */
 	size_t        next; /* where do we insert the next entry? */
 	challenge_t   cache[MAX_CHALLENGES];
-} challenges_t;
+} acme_t;
 
-static void acme_save(challenges_t *acme, name_t *query);
-static void acme_set(challenges_t *acme, const char *token, const char *domain);
-static void acme_free(challenges_t *acme);
+static void acme_save(acme_t *acme, name_t *query);
+static void acme_set(acme_t *acme, const char *token, const char *domain);
+static void acme_free(acme_t *acme);
 
 /*********************************************************************/
 
@@ -318,18 +318,18 @@ extract_delimited(char *s, char dlm, char **end)
 }
 
 static void
-acme_save(challenges_t *acme, name_t *query)
+acme_save(acme_t *acme, name_t *query)
 {
 	/* parse a name like `_acme-challenge.$NON.CE._.$SEA.LED.x.y.z`
 	   to get back $NONCE and $SEALED; returning 0 if we succeeded.
 	 */
 
-	char *token, *nonce, *sealed;
+	char *token  = NULL,
+	     *nonce  = NULL,
+	     *sealed = NULL;
 	char *s, *a, *b;
-	time_t now;
-	unsigned long notafter;
-
-	token = nonce = sealed = NULL;
+	time_t now = 0;
+	unsigned long notafter = 0;
 
 	a = s = name_string(query);
 	debugf("acme in [%s]\n", s);
@@ -381,7 +381,7 @@ acme_set_at(challenge_t *ch, const char *token, const char *domain)
 }
 
 static void
-acme_set(challenges_t *acme, const char *token, const char *domain)
+acme_set(acme_t *acme, const char *token, const char *domain)
 {
 	size_t i;
 	name_t *q;
@@ -408,7 +408,7 @@ done:
 }
 
 static void
-acme_free(challenges_t *acme)
+acme_free(acme_t *acme)
 {
 	size_t i;
 	for (i = 0; i < acme->used; i++) {
@@ -895,7 +895,7 @@ reply_txt(msg_t *m, const char *txt)
 }
 
 static int
-reply_acme(msg_t *m, challenges_t *acme, name_t *query)
+reply_acme(msg_t *m, acme_t *acme, name_t *query)
 {
 	size_t i;
 
@@ -991,7 +991,7 @@ int main(int argc, char **argv)
 	int test_max = 0;
 #endif
 
-	challenges_t acme;
+	acme_t acme;
 
 	struct timeval start, end;
 

--- a/netip.c
+++ b/netip.c
@@ -361,7 +361,7 @@ acme_save(acme_t *acme, name_t *query)
 	      into '_acme-challenge.tld' */
 	b = strchr(s, '.'); if (!b) goto done; b++;
 	memmove(b, a, strlen(a) + 1);
-	debugf("acme set [%s] challenge to [%s]\n", s, token);
+	fprintf(stderr, "acme %s for %s\n", token, s);
 	acme_set(acme, token, s);
 
 done:

--- a/seal.c
+++ b/seal.c
@@ -1,0 +1,162 @@
+#include <string.h>
+#include <sodium.h>
+#include <errno.h>
+#include <time.h>
+#include <assert.h>
+
+#include "seal.h"
+#include "base16.h"
+
+int seal_init()
+{
+	return sodium_init();
+}
+
+char *
+seal_keygen()
+{
+	char key[crypto_secretbox_KEYBYTES];
+	char *encoded;
+
+	randombytes_buf(key, crypto_secretbox_KEYBYTES);
+	encoded = malloc(b16elen(crypto_secretbox_KEYBYTES) + 1);
+	if (!encoded) return NULL;
+
+	b16e(encoded, key, crypto_secretbox_KEYBYTES);
+	encoded[b16elen(crypto_secretbox_KEYBYTES)] = '\0';
+	return encoded;
+}
+
+ssize_t
+seal(char **nonce, char **sealed, unsigned long until, const char *text, size_t len, const char *key)
+{
+	char *buf, *_sealed;
+	char _nonce[crypto_secretbox_NONCEBYTES];
+
+	/* check yo-self */
+	assert(nonce  != NULL);
+	assert(sealed != NULL);
+	assert(text   != NULL);
+	assert(key    != NULL);
+
+	assert(until < 0xffffffffff); /* we only want 40 bits */
+	assert(len < 4096); /* len has no business being astronomical */
+
+	/* initialize to sane defaults;
+	   this makes free(3) calls simpler.
+	 */
+	buf = _sealed = NULL;
+	*nonce = *sealed = NULL;
+
+	/* generate a random nonce (unencoded) */
+	randombytes_buf(_nonce, crypto_secretbox_NONCEBYTES);
+	memset(_nonce, 42, crypto_secretbox_NONCEBYTES);
+
+	/* encode the nonce under base-32 */
+	*nonce = malloc(ENCODED_NONCE_LEN);
+	if (!*nonce) goto fail;
+	b32e(*nonce, _nonce, sizeof(_nonce));
+
+	/* allocate the payload input buffer:
+	     5 bytes (40-bits) for the "freshness" indicator;
+	     $len bytes for the provided message contents; and
+	     enough bytes for the message auth (MAC)
+	 */
+	buf = malloc(len+5+crypto_secretbox_MACBYTES);
+	if (!buf) goto fail;
+
+	/* encode the freshness indicator into the first 5 bytes */
+	buf[0] = ((0xff00000000 & until) >> 32);
+	buf[1] = ((0x00ff000000 & until) >> 24);
+	buf[2] = ((0x0000ff0000 & until) >> 16);
+	buf[3] = ((0x000000ff00 & until) >>  8);
+	buf[4] = ((0x00000000ff & until)      );
+
+	/* copy the message text onto the end */
+	memcpy(buf+5, text, len);
+
+	/* allocate the encrypted output buffer (unencoded) */
+	_sealed = malloc(len+5+crypto_secretbox_MACBYTES);
+	if (!_sealed) goto fail;
+
+	/* allocate the encrypted output buffer (encoded) */
+	*sealed = malloc(b32elen(len+5+crypto_secretbox_MACBYTES));
+	if (!*sealed) goto fail;
+
+	/* encrypt! */
+	crypto_secretbox_easy(_sealed, buf, len+5, _nonce, key);
+
+	/* encode! */
+	b32e(*sealed, _sealed, len+5+crypto_secretbox_MACBYTES);
+
+	free(buf);
+	free(_sealed);
+	return b32elen(len+5+crypto_secretbox_MACBYTES);
+
+fail:
+	free(buf);
+	free(_sealed);
+	free(*nonce);
+	free(*sealed);
+	return -1;
+}
+
+#define MAX_SEALED_BYTES 512
+
+char *
+unseal(const char *nonce, char *sealed, size_t len, const char *key)
+{
+	char *text = NULL;
+	char buf[MAX_SEALED_BYTES];
+	char _nonce[crypto_secretbox_NONCEBYTES];
+	unsigned long notafter;
+	time_t now;
+
+	assert(nonce  != NULL);
+	assert(sealed != NULL);
+	assert(key    != NULL);
+
+	/* some length sanity checking */
+	if (b32dlen(len) < 6 || b32dlen(len) > MAX_SEALED_BYTES) goto fail;
+
+	/* decode the nonce */
+	b32d(_nonce, nonce, ENCODED_NONCE_LEN);
+
+	/* decode the input */
+	fprintf(stderr, "len %li will decode to %li; of which 5 bytes are freshness\n", len, b32dlen(len));
+	b32d(buf, sealed, len);
+	len = b32dlen(len);
+
+	/* decrypt the input */
+	if (crypto_secretbox_open_easy(buf, buf, len, _nonce, key) != 0) {
+		goto fail;
+	}
+
+	/* strip off the mac bytes */
+	len -= crypto_secretbox_MACBYTES;
+
+	/* check freshness */
+	notafter = (((unsigned long)buf[0] << 32) & 0xff00000000)
+	         | (((unsigned long)buf[1] << 24) & 0x00ff000000)
+	         | (((unsigned long)buf[2] << 16) & 0x0000ff0000)
+	         | (((unsigned long)buf[3] <<  8) & 0x000000ff00)
+	         | (((unsigned long)buf[4]      ) & 0x00000000ff);
+	now = time(NULL);
+	if (now < 0) goto fail;
+	if (now > notafter) {
+		errno = EINVAL;
+		goto fail;
+	}
+
+	/* extract the original payload */
+	text = malloc(len-5+1);
+	if (!text) goto fail;
+	memset(text, 0, len-5+1);
+	fprintf(stderr, "copying %li bytes into token; null-term at [%li]\n", len-5, len-5+1);
+	memcpy(text, buf+5, len-5);
+	return text;
+
+fail:
+	free(text);
+	return NULL;
+}

--- a/seal.c
+++ b/seal.c
@@ -123,7 +123,6 @@ unseal(const char *nonce, char *sealed, size_t len, const char *key)
 	b32d(_nonce, nonce, ENCODED_NONCE_LEN);
 
 	/* decode the input */
-	fprintf(stderr, "len %li will decode to %li; of which 5 bytes are freshness\n", len, b32dlen(len));
 	b32d(buf, sealed, len);
 	len = b32dlen(len);
 
@@ -152,7 +151,6 @@ unseal(const char *nonce, char *sealed, size_t len, const char *key)
 	text = malloc(len-5+1);
 	if (!text) goto fail;
 	memset(text, 0, len-5+1);
-	fprintf(stderr, "copying %li bytes into token; null-term at [%li]\n", len-5, len-5+1);
 	memcpy(text, buf+5, len-5);
 	return text;
 

--- a/seal.c
+++ b/seal.c
@@ -30,7 +30,8 @@ seal_keygen()
 ssize_t
 seal(char **nonce, char **sealed, unsigned long until, const char *text, size_t len, const char *key)
 {
-	char *buf, *_sealed;
+	char *buf     = NULL,
+	     *_sealed = NULL;
 	char _nonce[crypto_secretbox_NONCEBYTES];
 
 	/* check yo-self */
@@ -45,7 +46,6 @@ seal(char **nonce, char **sealed, unsigned long until, const char *text, size_t 
 	/* initialize to sane defaults;
 	   this makes free(3) calls simpler.
 	 */
-	buf = _sealed = NULL;
 	*nonce = *sealed = NULL;
 
 	/* generate a random nonce (unencoded) */

--- a/seal.h
+++ b/seal.h
@@ -1,0 +1,15 @@
+#ifndef __NETIP_SEAL_H
+#define __NETIP_SEAL_H
+
+#include <stddef.h>
+#include <sodium.h>
+
+#include "base32.h"
+#define ENCODED_NONCE_LEN b32elen(crypto_secretbox_NONCEBYTES)
+
+int seal_init();
+char * seal_keygen();
+ssize_t seal(char **nonce, char **sealed, unsigned long until, const char *text, size_t len, const char *key);
+char * unseal(const char *nonce, char *sealed, size_t len, const char *key);
+
+#endif


### PR DESCRIPTION
This PR provides (authenticated) support for ACME dns-01 challenges,
using a custom interpretation of specially crafted A records.

Each netip process now has a symmetric private key.  This key must
be shared with anyone attempting to enroll in automatic certificate
generation via ACME.  With that key, the client can issue the following
A record:

    IN A _acme-challenge.<nonce>._.<token>._.foo.1.2.3.4.netip.cc

The netip process will notice the leading `_acme-challenge` label and
engage the machinery to ingest a new dns-01 challenge TXT record.
It extracts the `<nonce>` value (which may be split across multiple DNS
labels to abide the 63-character label length limit.  For example, given
the following:

    IN A _acme-challenge.abcd.efgh._.<token>._.foo.1.2.3.4.netip.cc

The nonce `abcdefgh` will be extracted.  This is treated as a base-32
encoded string, and decoded to get the actual nonce value.

Next, the token (also base-32 encoded) is extracted in a similar fashion;
multiple labels are coalesced, the value is decoded, etc.

Note: this is why we have the `_` labels; they act as delimiters between
the nonce, the token, and the rest of the query.

The token is then decrypted with the nonce and netip private key,
authenticated (using an embedded message authentication code), and
checked for a lifetime freshness (using an embedded 40-bit timestamp).
This last check helps to protect against replay attacks by expiring the
(cleartext and imminently repeatable) DNS A queries.

If everything checks out, netip will update the IN TXT record for the
actual `_acme-challenge.<domain>` record.  Each domain gets exactly
one token at a time; updates will replace the existing challenge token.

The TXT record is created by dropping the `<nonce>._.<token>._`
labels out of the A query and using that.  Using our example from above:

    IN A _acme-challenge.<nonce>._.<token>._.foo.1.2.3.4.netip.cc

would in turn populate the answer to the following query:

    IN TXT _acme-challenge.foo.1.2.3.4.netip.cc

Generating the A query involves some delicate cryptography that is
difficult to do by hand.  Generating keys is possible (by hand), but
is better done by a machine.  To make these tasks easier, `netip` has
some new modes of operation:

    netip -K

Will generate a new key, and properly encode it under the base-16
binary-to-text encoding system (commonly called "hex encoding").

    netip -k $A_KEY_IN_HEX -t $A_TOKEN -d foo.1.2.3.4.netip.cc

Will print out the appropriate IN A query domain, properly encrypted
with a random nonce and a 30-second lifetime, for example:

    $ netip -k $(netip -K) -t a-dns-01-challenge-token -d foo.1.2.3.4.netip.cc
    _acme-challenge.58l2kaha58l2kaha58l2kaha58l2kaha58l2kag._.u5b3i2flrqh4tpvgqkv7kgnklklp7akal60o1seffpo9p00hpvs41suihgrcsif.j8dmfvckp._.foo.1.2.3.4.netip.cc

If you wish to verify the label-breaking algorithm, to ensure that it abides
by the 63-character limit, here's a perl script:

    $ netip -k ... -t ... | \
      perl -e 'while(<>){print;chomp;for(split(/\./, $_)){print " - $_: ".length($_)."\n";}}'

This is a closed system; it does not currently enable unfettered access
to the ACME dns-01 subsystem (although a previous version did, which
raised some terms-of-service questions that are still unanswered).